### PR TITLE
Remove option to select temporary folder as an output destination

### DIFF
--- a/MapsPrinter/processing_provider/export_layouts_from_folder.py
+++ b/MapsPrinter/processing_provider/export_layouts_from_folder.py
@@ -24,11 +24,10 @@ import glob
 import qgis
 from qgis.core import (QgsProject,
                        QgsProcessingAlgorithm,
-                       QgsProcessingParameterBoolean,
-                       QgsProcessingParameterFolderDestination,
-                       QgsProcessingParameterFile,
-                       QgsProcessingParameterEnum,
                        QgsProcessingOutputFolder,
+                       QgsProcessingParameterBoolean,
+                       QgsProcessingParameterEnum,
+                       QgsProcessingParameterFile,
                        QgsProcessingParameterNumber,
                       )
 from qgis.PyQt.QtCore import QCoreApplication
@@ -97,9 +96,10 @@ class ExportLayoutsFromFolder(QgsProcessingAlgorithm):
             )
         )
         self.addParameter(
-            QgsProcessingParameterFolderDestination(
+            QgsProcessingParameterFile(
                 self.OUTPUT_FOLDER,
-                self.tr("Output folder where to save maps")
+                self.tr("Output folder where to save maps"),
+                QgsProcessingParameterFile.Folder
             )
         )
         self.addOutput(

--- a/MapsPrinter/processing_provider/export_layouts_from_project.py
+++ b/MapsPrinter/processing_provider/export_layouts_from_project.py
@@ -33,7 +33,7 @@ from qgis.core import (QgsProcessingAlgorithm,
                        QgsProcessingMultiStepFeedback,
                        QgsProcessingOutputNumber,
                        QgsProcessingParameterEnum,
-                       QgsProcessingParameterFolderDestination,
+                       QgsProcessingParameterFile,
                        QgsProcessingParameterNumber,
                       )
 from processing.core.ProcessingConfig import ProcessingConfig
@@ -104,9 +104,10 @@ class ExportLayoutsFromProject(QgsProcessingAlgorithm):
         )
 
         self.addParameter(
-            QgsProcessingParameterFolderDestination(
+            QgsProcessingParameterFile(
                 self.OUTPUT,
-                self.tr('Output folder where to save maps')
+                self.tr('Output folder where to save maps'),
+                QgsProcessingParameterFile.Folder
             )
         )
 


### PR DESCRIPTION
Fixes #47 
I couldn't find a plugin doing that and even core "export layout..." algs use a plain folder so let's follow them